### PR TITLE
fix typo in `pytest.yaml`

### DIFF
--- a/.github/workflow/pytest.yaml
+++ b/.github/workflow/pytest.yaml
@@ -3,10 +3,10 @@ name: Pytest
 on:
   push:
     branches:
-      - "maIN"
+      - "main"
   pull_request:
     branches:
-      - "maIN"
+      - "main"
 
 jobs:
   test:
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+          python-version: ["3.9", "3.10", "3.11"]
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Fixes #28.

Fix typo in the word `maIN`